### PR TITLE
check_structure couldn't find after install the package

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -23,6 +23,7 @@ setuptools.setup(
     packages=setuptools.find_packages(exclude=['docs', 'test']),
     include_package_data=True,
     install_requires=['biobb_structure_manager==1.0.0'],
+    scripts=['bin/check_structure'],
     python_requires='==3.6.*',
     classifiers=(
         "Development Status :: 3 - Alpha",


### PR DESCRIPTION
Hi, thanks for developing nice package.
I used these packages and I'm learning MD tutorial. The code was failed because check_structure is not callable.
I think 'scripts=[bin/check_structure]' should be added setup.py.
Thanks

Taka