### PR TITLE
non_interactive defaults

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@
 - Fix charge assignment for modified residues and terminals
 - Fixed wrong assigment of RNA residues as protein
 - Fixed tests
+- Fixed behaviour with --non_interactive and missing command options
 
 ***
 ## V3.8.5 (2021.2)

--- a/biobb_structure_checking/docs/source/changelog.md
+++ b/biobb_structure_checking/docs/source/changelog.md
@@ -21,7 +21,8 @@
 - Fix charge assignment for modified residues and terminals
 - Fixed wrong assigment of RNA residues as protein
 - Fixed tests
--
+- Fixed behaviour with --non_interactive and missing command options
+
 ***
 ## V3.8.5 (2021.2)
 

--- a/biobb_structure_checking/param_input.py
+++ b/biobb_structure_checking/param_input.py
@@ -15,11 +15,12 @@ def _get_input(value, prompt_text, default=None):
 
 class ParamInput():
     """ Class to generate and manage interactive parameter dialogs"""
-    def __init__(self, prefix, non_interactive=True):
+    def __init__(self, prefix, non_interactive=True, set_none = 'none'):
         self.options = []
         self.non_interactive = non_interactive
         self.prefix = prefix
         self.default = None
+        self.default_none = set_none
 
     def add_option_all(self):
         """ Add 'All' option to dialog"""
@@ -62,7 +63,9 @@ class ParamInput():
             'label':label,
             'type':input,
         })
-
+    def set_default(self, value):
+        self.default = value
+        
     def _build_dialog(self):
         if not self.options:
             return self.prefix + ': '
@@ -127,16 +130,18 @@ class ParamInput():
 
     def run(self, opt_value):
         """ Build and execute dialog"""
-
         # Non interactive enviroment, check available input only
         if self.non_interactive:
-            # No options, nothing to do, return original value
+            if opt_value is None:
+                print(f" WARNING: No selection provided and non_interactive, using '{self.default_none}'")
+                opt_value = self.default_none
+                        # No options, nothing to do, return original value
             if not self.options:
                 return opt_value
             # Check input
             input_ok, iopt, opt_value = self._check_dialog_value(opt_value)
             if not input_ok:
-                print('Input not valid ({})'.format(opt_value))
+                print(f'Input not valid ({opt_value})')
                 self.options.append({'label':'error'})
             return [self.options[iopt]['label'], opt_value]
 
@@ -151,7 +156,7 @@ class ParamInput():
             opt_value = _get_input(opt_value, prompt_str, self.default)
             input_ok, iopt, opt_value = self._check_dialog_value(opt_value)
             if not input_ok:
-                print('Input not valid ({})'.format(opt_value))
+                print(f'Input not valid ({opt_value})')
                 opt_value = ''
         return self.options[iopt]['label'], opt_value
 

--- a/biobb_structure_checking/structure_checking.py
+++ b/biobb_structure_checking/structure_checking.py
@@ -175,8 +175,12 @@ class StructureChecking():
         except NoDialogAvailableError as err:
             print(err.message)
         
-        if not op_list and not self.args['non_interactive']:
-            op_list = ParamInput('Command List File', False).run(op_list)
+        if not op_list:
+            if not self.args['non_interactive']:
+                op_list = ParamInput('Command List File', False).run(op_list)
+            else:
+                sys.exit(f'ERROR: command list not provided and non_interactive')
+            
 
         if os.path.isfile(op_list):
             command_list = []
@@ -285,8 +289,12 @@ class StructureChecking():
                         if k not in opts:
                             opts[k] = defs[k]
             error_status = f_fix(opts, data_to_fix)
-
+            
             if error_status:
+                if isinstance(error_status, tuple):
+                    if error_status[1] is None:
+                        error_status = [error_status[0]]
+                    
                 print('ERROR', ' '.join(error_status), file=sys.stderr)
                 self.summary[command]['error'] = ' '.join(error_status)
 
@@ -361,13 +369,12 @@ class StructureChecking():
             select_model = opts
         else:
             select_model = opts['select']
-
-        input_line = ParamInput('Select Model Num', self.args['non_interactive'])
+        
+        input_line = ParamInput('Select Model Num', self.args['non_interactive'], set_none='All')
         input_line.add_option_all()
         input_line.add_option_numeric(
             'modelno', [], opt_type='int', min_val=1, max_val=self.strucm.nmodels
         )
-
         input_option, select_model = input_line.run(select_model)
 
         if input_option == 'error':
@@ -421,9 +428,9 @@ class StructureChecking():
             select_chains = opts
         else:
             select_chains = opts['select']
-
+        
         self.summary['chains']['selected'] = {}
-        input_line = ParamInput('Select chain', self.args['non_interactive'])
+        input_line = ParamInput('Select chain', self.args['non_interactive'], set_none='All')
         input_line.add_option_all()
         input_line.add_option_list(
             'type', ['protein'], multiple=False
@@ -440,7 +447,8 @@ class StructureChecking():
         input_line.add_option_list(
             'chid', sorted(self.strucm.chain_ids), multiple=True, case="sensitive"
         )
-        input_line.default = 'All'
+        input_line.set_default('All')
+
         input_option, select_chains = input_line.run(select_chains)
 
         if input_option == 'error':
@@ -537,7 +545,7 @@ class StructureChecking():
             select_altloc = opts
         else:
             select_altloc = opts['select']
-
+            
         # Prepare the longest possible list of alternatives
         altlocs = []
         max_al_len = 0
@@ -546,7 +554,8 @@ class StructureChecking():
                 altlocs = fix_data['altlocs'][res]
                 max_al_len = len(fix_data['altlocs'][res])
 
-        input_line = ParamInput('Select alternative', self.args['non_interactive'])
+        input_line = ParamInput('Select alternative', self.args['non_interactive'], set_none='All')
+        input_line.add_option_all()
         input_line.add_option_list('occup', ['occupancy'])
         input_line.add_option_list('altids', altlocs, case='upper')
         input_line.add_option_list(
@@ -557,41 +566,42 @@ class StructureChecking():
             case='sensitive',
             multiple=True
         )
-        input_line.default = 'occupancy'
+        input_line.set_default('occupancy')
+
         input_option, select_altloc = input_line.run(select_altloc)
 
         if input_option == 'error':
             return cts.MSGS['UNKNOWN_SELECTION'], select_altloc
-
-        print('Selecting location {}'.format(select_altloc))
-        if input_option in ('occup', 'altids'):
-            select_altloc = select_altloc.upper()
-            to_fix = {
-                res: {
-                    'ats': value,
-                    'select' : select_altloc
-                } for res, value in fix_data['alt_loc_res'].items()
-            }
-
-        elif input_option == 'resnum':
-            to_fix = {}
-            selected_rnums = {}
-            for rsel in select_altloc.split(','):
-                rnum, alt = rsel.split(':')
-                selected_rnums[rnum] = alt
-            to_fix = {
-                res : {
-                    'ats' : value,
-                    'select' : selected_rnums[mu.residue_num(res)]
+        
+        if input_option != 'all':
+            print('Selecting location {}'.format(select_altloc))
+            if input_option in ('occup', 'altids'):
+                select_altloc = select_altloc.upper()
+                to_fix = {
+                    res: {
+                        'ats': value,
+                        'select' : select_altloc
+                    } for res, value in fix_data['alt_loc_res'].items()
                 }
-                for res, value in fix_data['alt_loc_res'].items()
-                if mu.residue_num(res) in selected_rnums
-            }
+
+            elif input_option == 'resnum':
+                to_fix = {}
+                selected_rnums = {}
+                for rsel in select_altloc.split(','):
+                    rnum, alt = rsel.split(':')
+                    selected_rnums[rnum] = alt
+                to_fix = {
+                    res : {
+                        'ats' : value,
+                        'select' : selected_rnums[mu.residue_num(res)]
+                    }
+                    for res, value in fix_data['alt_loc_res'].items()
+                    if mu.residue_num(res) in selected_rnums
+                }
+            for res in to_fix:
+                self.strucm.select_altloc_residue(res, to_fix[res])
 
         self.summary['altloc']['selected'] = select_altloc
-
-        for res in to_fix:
-            self.strucm.select_altloc_residue(res, to_fix[res])
 
         return False
 # =============================================================================
@@ -640,7 +650,7 @@ class StructureChecking():
             remove_metals = opts
         else:
             remove_metals = opts['remove']
-
+        
         input_line = ParamInput("Remove", self.args['non_interactive'])
         input_line.add_option_all()
         input_line.add_option_none()
@@ -651,7 +661,7 @@ class StructureChecking():
             multiple=True
         )
         input_line.add_option_list('resids', fix_data['met_rids'], case='sensitive', multiple=True)
-        input_line.default = 'All'
+        input_line.set_default('All')
         input_option, remove_metals = input_line.run(remove_metals)
 
         if input_option == "error":
@@ -720,9 +730,10 @@ class StructureChecking():
             remove_wat = opts
         else:
             remove_wat = opts['remove']
-        input_line = ParamInput('Remove', self.args['non_interactive'])
+        
+        input_line = ParamInput('Remove', self.args['non_interactive'], set_none='no')
         input_line.add_option_yes_no()
-        input_line.default = 'yes'
+        input_line.set_default('yes')
         input_option, remove_wat = input_line.run(remove_wat)
 
         if input_option == 'error':
@@ -804,7 +815,7 @@ class StructureChecking():
         input_line.add_option_list(
             'byresnum', fix_data['ligand_rnums'], case='sensitive', multiple=True
         )
-        input_line.default = 'all'
+        input_line.set_default('All')
         input_option, remove_ligands = input_line.run(remove_ligands)
 
         if input_option == 'error':
@@ -868,9 +879,11 @@ class StructureChecking():
             remove_h = opts
         else:
             remove_h = opts['remove']
-        input_line = ParamInput('Remove hydrogen atoms', self.args['non_interactive'])
+
+        input_line = ParamInput('Remove hydrogen atoms', self.args['non_interactive'], set_none='no')
         input_line.add_option_yes_no()
-        input_line.default = 'yes'
+        input_line.set_default('yes')
+
         input_option, remove_h = input_line.run(remove_h)
 
         if input_option == 'error':
@@ -940,7 +953,7 @@ class StructureChecking():
         input_line.add_option_list(
             'bypair', pairs_list, multiple=True
         )
-        input_line.default = 'all'
+        input_line.set_default('All')
         input_option, getss_mark = input_line.run(getss_mark)
 
         if input_option == 'error':
@@ -1028,7 +1041,7 @@ class StructureChecking():
                 case='sensitive',
                 multiple=True
             )
-            input_line.default = 'All'
+            input_line.set_default('All')
             input_option, amide_fix = input_line.run(amide_fix)
 
             if input_option == 'error':
@@ -1119,7 +1132,7 @@ class StructureChecking():
             case='sensitive',
             multiple=True
         )
-        input_line.default = 'all'
+        input_line.set_default('All')
         input_option, chiral_fix = input_line.run(chiral_fix)
 
         if input_option == 'error':
@@ -1293,7 +1306,7 @@ class StructureChecking():
         input_line.add_option_list(
             'resnum', fixside_rnums, case='sensitive', multiple=True
         )
-        input_line.default = 'all'
+        input_line.set_default('All')
         input_option_fix, fix_side = input_line.run(fix_side)
 
         if input_option_fix == 'error':
@@ -1427,7 +1440,7 @@ class StructureChecking():
         if fix_data['ion_res_list']:
             sel_options += ['pH', 'list', 'int', 'int_his']
         input_line.add_option_list('selection', sel_options)
-        input_line.default = 'auto'
+        input_line.set_default('auto')
         input_option, add_h_mode = input_line.run(add_h_mode)
 
         if input_option == 'error':
@@ -1453,8 +1466,9 @@ class StructureChecking():
         else:
             if add_h_mode == 'ph':
                 ph_value = opts['pH']
-                input_line = ParamInput("pH Value", self.args['non_interactive'])
+                input_line = ParamInput("pH Value", self.args['non_interactive'], set_none=7.0)
                 input_line.add_option_numeric("pH", [], opt_type="float", min_val=0., max_val=14.)
+                input_line.set_default(7.0)
                 input_option, ph_value = input_line.run(ph_value)
                 if not self.args['quiet']:
                     print('Selection: pH', ph_value)
@@ -1535,9 +1549,15 @@ class StructureChecking():
         if opts['na_seq']:
             mut_list = self.strucm.prepare_mutations_from_na_seq(opts['na_seq'])
 
-        input_line = ParamInput('Mutation list', self.args['non_interactive'])
-        mut_list = input_line.run(mut_list)
+        input_line = ParamInput('Mutation list', self.args['non_interactive'], set_none='')
 
+        mut_list = input_line.run(mut_list)
+        
+        if mut_list == '':
+            if self.args['verbose']:
+                print(cts.MSGS['DO_NOTHING'])
+            return False   
+        
         mutations = self.strucm.prepare_mutations(mut_list)
 
         print(cts.MSGS['MUTATIONS_TO_DO'])
@@ -1674,7 +1694,7 @@ class StructureChecking():
         fix_done = not fix_data['bck_breaks_list']
         fixed_main_res = []
         while not fix_done:
-            if not opts['extra_gap']:
+            if opts['extra_gap'] is None:
                 opts['extra_gap'] = 0
             fixed_main = self._backbone_fix_main_chain(
                 opts['fix_chain'],
@@ -1751,7 +1771,7 @@ class StructureChecking():
         input_line.add_option_list(
             'brk', brk_rnums, case='sensitive', multiple=True
         )
-        input_line.default = 'all'
+        input_line.set_default('All')
         input_option, fix_main_bck = input_line.run(fix_main_bck)
 
         if input_option == 'error':
@@ -1828,7 +1848,7 @@ class StructureChecking():
         input_line.add_option_list(
             'resnum', term_rnums, case='sensitive', multiple=True
         )
-        input_line.default = 'none'
+        input_line.set_default('none')
         input_option, add_caps = input_line.run(add_caps)
 
         if input_option == 'error':
@@ -1862,7 +1882,7 @@ class StructureChecking():
         input_line.add_option_list(
             'resnum', fixbck_rnums, case='sensitive', multiple=True
         )
-        input_line.default = 'none'
+        input_line.set_default('none')
         input_option, fix_back = input_line.run(fix_back)
 
         if input_option == 'error':
@@ -2018,10 +2038,10 @@ class StructureChecking():
         """
         input_line = ParamInput(
             "Enter output structure path",
-            self.args['non_interactive']
+            self.args['non_interactive'],
+            set_none='fixed_structure.pdb'
         )
         output_structure_path = input_line.run(output_structure_path)
-        
         output_format = os.path.splitext(output_structure_path)[1][1:]
         
         self.strucm.save_structure(output_structure_path, rename_terms=rename_terms, output_format=output_format)

--- a/biobb_structure_checking/structure_checking.py
+++ b/biobb_structure_checking/structure_checking.py
@@ -175,8 +175,12 @@ class StructureChecking():
         except NoDialogAvailableError as err:
             print(err.message)
         
-        if not op_list and not self.args['non_interactive']:
-            op_list = ParamInput('Command List File', False).run(op_list)
+        if not op_list:
+            if not self.args['non_interactive']:
+                op_list = ParamInput('Command List File', False).run(op_list)
+            else:
+                sys.exit(f'ERROR: command list not provided and non_interactive')
+            
 
         if os.path.isfile(op_list):
             command_list = []
@@ -285,8 +289,12 @@ class StructureChecking():
                         if k not in opts:
                             opts[k] = defs[k]
             error_status = f_fix(opts, data_to_fix)
-
+            
             if error_status:
+                if isinstance(error_status, tuple):
+                    if error_status[1] is None:
+                        error_status = [error_status[0]]
+                    
                 print('ERROR', ' '.join(error_status), file=sys.stderr)
                 self.summary[command]['error'] = ' '.join(error_status)
 
@@ -361,13 +369,12 @@ class StructureChecking():
             select_model = opts
         else:
             select_model = opts['select']
-
-        input_line = ParamInput('Select Model Num', self.args['non_interactive'])
+        
+        input_line = ParamInput('Select Model Num', self.args['non_interactive'], set_none='All')
         input_line.add_option_all()
         input_line.add_option_numeric(
             'modelno', [], opt_type='int', min_val=1, max_val=self.strucm.nmodels
         )
-
         input_option, select_model = input_line.run(select_model)
 
         if input_option == 'error':
@@ -421,9 +428,9 @@ class StructureChecking():
             select_chains = opts
         else:
             select_chains = opts['select']
-
+        
         self.summary['chains']['selected'] = {}
-        input_line = ParamInput('Select chain', self.args['non_interactive'])
+        input_line = ParamInput('Select chain', self.args['non_interactive'], set_none='All')
         input_line.add_option_all()
         input_line.add_option_list(
             'type', ['protein'], multiple=False
@@ -440,7 +447,8 @@ class StructureChecking():
         input_line.add_option_list(
             'chid', sorted(self.strucm.chain_ids), multiple=True, case="sensitive"
         )
-        input_line.default = 'All'
+        input_line.set_default('All')
+
         input_option, select_chains = input_line.run(select_chains)
 
         if input_option == 'error':
@@ -537,7 +545,7 @@ class StructureChecking():
             select_altloc = opts
         else:
             select_altloc = opts['select']
-
+            
         # Prepare the longest possible list of alternatives
         altlocs = []
         max_al_len = 0
@@ -546,7 +554,8 @@ class StructureChecking():
                 altlocs = fix_data['altlocs'][res]
                 max_al_len = len(fix_data['altlocs'][res])
 
-        input_line = ParamInput('Select alternative', self.args['non_interactive'])
+        input_line = ParamInput('Select alternative', self.args['non_interactive'], set_none='All')
+        input_line.add_option_all()
         input_line.add_option_list('occup', ['occupancy'])
         input_line.add_option_list('altids', altlocs, case='upper')
         input_line.add_option_list(
@@ -557,41 +566,42 @@ class StructureChecking():
             case='sensitive',
             multiple=True
         )
-        input_line.default = 'occupancy'
+        input_line.set_default('occupancy')
+
         input_option, select_altloc = input_line.run(select_altloc)
 
         if input_option == 'error':
             return cts.MSGS['UNKNOWN_SELECTION'], select_altloc
-
-        print('Selecting location {}'.format(select_altloc))
-        if input_option in ('occup', 'altids'):
-            select_altloc = select_altloc.upper()
-            to_fix = {
-                res: {
-                    'ats': value,
-                    'select' : select_altloc
-                } for res, value in fix_data['alt_loc_res'].items()
-            }
-
-        elif input_option == 'resnum':
-            to_fix = {}
-            selected_rnums = {}
-            for rsel in select_altloc.split(','):
-                rnum, alt = rsel.split(':')
-                selected_rnums[rnum] = alt
-            to_fix = {
-                res : {
-                    'ats' : value,
-                    'select' : selected_rnums[mu.residue_num(res)]
+        
+        if input_option != 'all':
+            print('Selecting location {}'.format(select_altloc))
+            if input_option in ('occup', 'altids'):
+                select_altloc = select_altloc.upper()
+                to_fix = {
+                    res: {
+                        'ats': value,
+                        'select' : select_altloc
+                    } for res, value in fix_data['alt_loc_res'].items()
                 }
-                for res, value in fix_data['alt_loc_res'].items()
-                if mu.residue_num(res) in selected_rnums
-            }
+
+            elif input_option == 'resnum':
+                to_fix = {}
+                selected_rnums = {}
+                for rsel in select_altloc.split(','):
+                    rnum, alt = rsel.split(':')
+                    selected_rnums[rnum] = alt
+                to_fix = {
+                    res : {
+                        'ats' : value,
+                        'select' : selected_rnums[mu.residue_num(res)]
+                    }
+                    for res, value in fix_data['alt_loc_res'].items()
+                    if mu.residue_num(res) in selected_rnums
+                }
+            for res in to_fix:
+                self.strucm.select_altloc_residue(res, to_fix[res])
 
         self.summary['altloc']['selected'] = select_altloc
-
-        for res in to_fix:
-            self.strucm.select_altloc_residue(res, to_fix[res])
 
         return False
 # =============================================================================
@@ -640,7 +650,7 @@ class StructureChecking():
             remove_metals = opts
         else:
             remove_metals = opts['remove']
-
+        
         input_line = ParamInput("Remove", self.args['non_interactive'])
         input_line.add_option_all()
         input_line.add_option_none()
@@ -651,7 +661,7 @@ class StructureChecking():
             multiple=True
         )
         input_line.add_option_list('resids', fix_data['met_rids'], case='sensitive', multiple=True)
-        input_line.default = 'All'
+        input_line.set_default('All')
         input_option, remove_metals = input_line.run(remove_metals)
 
         if input_option == "error":
@@ -720,9 +730,10 @@ class StructureChecking():
             remove_wat = opts
         else:
             remove_wat = opts['remove']
-        input_line = ParamInput('Remove', self.args['non_interactive'])
+        
+        input_line = ParamInput('Remove', self.args['non_interactive'], set_none='no')
         input_line.add_option_yes_no()
-        input_line.default = 'yes'
+        input_line.set_default('yes')
         input_option, remove_wat = input_line.run(remove_wat)
 
         if input_option == 'error':
@@ -804,7 +815,7 @@ class StructureChecking():
         input_line.add_option_list(
             'byresnum', fix_data['ligand_rnums'], case='sensitive', multiple=True
         )
-        input_line.default = 'all'
+        input_line.set_default('All')
         input_option, remove_ligands = input_line.run(remove_ligands)
 
         if input_option == 'error':
@@ -868,9 +879,11 @@ class StructureChecking():
             remove_h = opts
         else:
             remove_h = opts['remove']
-        input_line = ParamInput('Remove hydrogen atoms', self.args['non_interactive'])
+
+        input_line = ParamInput('Remove hydrogen atoms', self.args['non_interactive'], set_none='no')
         input_line.add_option_yes_no()
-        input_line.default = 'yes'
+        input_line.set_default('yes')
+
         input_option, remove_h = input_line.run(remove_h)
 
         if input_option == 'error':
@@ -940,7 +953,7 @@ class StructureChecking():
         input_line.add_option_list(
             'bypair', pairs_list, multiple=True
         )
-        input_line.default = 'all'
+        input_line.set_default('All')
         input_option, getss_mark = input_line.run(getss_mark)
 
         if input_option == 'error':
@@ -1028,7 +1041,7 @@ class StructureChecking():
                 case='sensitive',
                 multiple=True
             )
-            input_line.default = 'All'
+            input_line.set_default('All')
             input_option, amide_fix = input_line.run(amide_fix)
 
             if input_option == 'error':
@@ -1119,7 +1132,7 @@ class StructureChecking():
             case='sensitive',
             multiple=True
         )
-        input_line.default = 'all'
+        input_line.set_default('All')
         input_option, chiral_fix = input_line.run(chiral_fix)
 
         if input_option == 'error':
@@ -1293,7 +1306,7 @@ class StructureChecking():
         input_line.add_option_list(
             'resnum', fixside_rnums, case='sensitive', multiple=True
         )
-        input_line.default = 'all'
+        input_line.set_default('All')
         input_option_fix, fix_side = input_line.run(fix_side)
 
         if input_option_fix == 'error':
@@ -1427,7 +1440,7 @@ class StructureChecking():
         if fix_data['ion_res_list']:
             sel_options += ['pH', 'list', 'int', 'int_his']
         input_line.add_option_list('selection', sel_options)
-        input_line.default = 'auto'
+        input_line.set_default('auto')
         input_option, add_h_mode = input_line.run(add_h_mode)
 
         if input_option == 'error':
@@ -1453,8 +1466,9 @@ class StructureChecking():
         else:
             if add_h_mode == 'ph':
                 ph_value = opts['pH']
-                input_line = ParamInput("pH Value", self.args['non_interactive'])
+                input_line = ParamInput("pH Value", self.args['non_interactive'], set_none=7.0)
                 input_line.add_option_numeric("pH", [], opt_type="float", min_val=0., max_val=14.)
+                input_line.set_default(7.0)
                 input_option, ph_value = input_line.run(ph_value)
                 if not self.args['quiet']:
                     print('Selection: pH', ph_value)
@@ -1536,8 +1550,13 @@ class StructureChecking():
             mut_list = self.strucm.prepare_mutations_from_na_seq(opts['na_seq'])
 
         input_line = ParamInput('Mutation list', self.args['non_interactive'])
+        input_line.add_option_none()
         mut_list = input_line.run(mut_list)
-
+        if mut_list == 'none':
+            if self.args['verbose']:
+                print(cts.MSGS['DO_NOTHING'])
+            return False   
+        
         mutations = self.strucm.prepare_mutations(mut_list)
 
         print(cts.MSGS['MUTATIONS_TO_DO'])
@@ -1674,7 +1693,7 @@ class StructureChecking():
         fix_done = not fix_data['bck_breaks_list']
         fixed_main_res = []
         while not fix_done:
-            if not opts['extra_gap']:
+            if opts['extra_gap'] is None:
                 opts['extra_gap'] = 0
             fixed_main = self._backbone_fix_main_chain(
                 opts['fix_chain'],
@@ -1751,7 +1770,7 @@ class StructureChecking():
         input_line.add_option_list(
             'brk', brk_rnums, case='sensitive', multiple=True
         )
-        input_line.default = 'all'
+        input_line.set_default('All')
         input_option, fix_main_bck = input_line.run(fix_main_bck)
 
         if input_option == 'error':
@@ -1828,7 +1847,7 @@ class StructureChecking():
         input_line.add_option_list(
             'resnum', term_rnums, case='sensitive', multiple=True
         )
-        input_line.default = 'none'
+        input_line.set_default('none')
         input_option, add_caps = input_line.run(add_caps)
 
         if input_option == 'error':
@@ -1862,7 +1881,7 @@ class StructureChecking():
         input_line.add_option_list(
             'resnum', fixbck_rnums, case='sensitive', multiple=True
         )
-        input_line.default = 'none'
+        input_line.set_default('none')
         input_option, fix_back = input_line.run(fix_back)
 
         if input_option == 'error':
@@ -2018,10 +2037,10 @@ class StructureChecking():
         """
         input_line = ParamInput(
             "Enter output structure path",
-            self.args['non_interactive']
+            self.args['non_interactive'],
+            set_none='fixed_structure.pdb'
         )
         output_structure_path = input_line.run(output_structure_path)
-        
         output_format = os.path.splitext(output_structure_path)[1][1:]
         
         self.strucm.save_structure(output_structure_path, rename_terms=rename_terms, output_format=output_format)


### PR DESCRIPTION
- Fixed behaviour for empty options when --non_interactive is set. Defaults to 'none' or 'no' for operations involving changes in the structure and to 'All' for selections (so no effect). 
- Warning messages provided
- Provided a fix output_path when no output file is indicated
