### PR TITLE
Added support for --keep_canonical_resnames

### DIFF
--- a/biobb_structure_checking/constants.py
+++ b/biobb_structure_checking/constants.py
@@ -136,6 +136,13 @@ CMD_LINE.add_argument(
 )
 
 CMD_LINE.add_argument(
+    '--keep_canonical_resnames',
+    action="store_true",
+    dest='keep_canonical',
+    help='Keep canonical names for ionized residues in output files'
+)
+
+CMD_LINE.add_argument(
     '--rename_terms',
     action="store_true",
     dest='rename_terms',

--- a/biobb_structure_checking/dat/commands.hlp
+++ b/biobb_structure_checking/dat/commands.hlp
@@ -42,7 +42,7 @@ add_hydrogen [--add_mode auto | pH | list | interactive | interactive_his] [--no
     Fixes missing side chain atoms unless --no_fix_side is set
     Existing hydrogen atoms are removed before adding new ones unless --keep_h set.
     --add_charges FF adds partial charges (from RES_LIBRARY) and atom types from FF forcefield. Output format taken from file extension or --output_format
-
+    Residue names are modified according to ionization state (e.g. HIS-> HIE, HID, HIP). Use --keep_canonical_resnames to avoid this behaviour
 2. Fix Structure Errors
 
 amide  [--fix All|None|Residue List] [--no_recheck]

--- a/biobb_structure_checking/docs/source/command_line_usage.md
+++ b/biobb_structure_checking/docs/source/command_line_usage.md
@@ -63,6 +63,8 @@ usage: check_structure [-h] [-i INPUT_STRUCTURE_PATH]
 
 **--output_format** OUTPUT_FORMAT - _Format for the Output._
 * pdb|pdbqt|pqr|cmip formats available (if empty file extension is used)
+
+**--keep_canonical_resnames** - _Revert output to canonical residue names when modified by any operation_
   
 **--json** JSON_OUTPUT_PATH - _Store a summary of all activities on a json file_
 

--- a/biobb_structure_checking/docs/source/commands_help.md
+++ b/biobb_structure_checking/docs/source/commands_help.md
@@ -52,6 +52,7 @@ _Mutate side chain with minimal atom replacement_
 * Existing hydrogen atoms are removed before adding new ones unless **--keep_h** is set.  
 * **--add_charges FF** adds partial charges (from RES_LIBRARY) and atom types from FF forcefield (Accepted: ATD, CMIP).  
 * Output format taken from file extension (Accepted: pdb, pdbqt, pqr) or --output_format.
+* Residue names are modified according to ionization state (e.g. HIS-> HIE, HID, HIP). Use --keep_canonical_resnames to avoid this behaviour
 
 ### Fix Structure Errors
 Commands to detect and fix possible structure errors. 

--- a/biobb_structure_checking/structure_checking.py
+++ b/biobb_structure_checking/structure_checking.py
@@ -2029,7 +2029,7 @@ class StructureChecking():
 
         return strucm
     
-    def save_structure(self, output_structure_path, rename_terms=False, split_models=False):
+    def save_structure(self, output_structure_path, rename_terms=False, split_models=False, keep_resnames=False):
         """ StuctureChecking.save_structure
         Saving the current structure in a the output file
         
@@ -2037,6 +2037,7 @@ class StructureChecking():
             output_structure_path (str): Path to saved File
             rename_terms (bool): (False) Rename terminal residues as NXXX, CXXX
             split_models (bool): (False) Save models in separated output files
+            keep_resnames (bool): (False) Keep canonical residue names
         """
         return self._save_structure(output_structure_path, rename_terms=rename_terms, split_models=split_models)
     
@@ -2049,6 +2050,7 @@ class StructureChecking():
             output_structure_path (str): Path to saved File
             rename_terms (bool): (False) Rename terminal residues as NXXX, CXXX
             split_models (bool): (False) Save models in separated output files
+            keep_resnames (bool): (False) Keep canonical residue names        
         """
         input_line = ParamInput(
             "Enter output structure path",
@@ -2061,13 +2063,24 @@ class StructureChecking():
             output_format = self.args['output_format']
         else:
             output_format = os.path.splitext(output_structure_path)[1][1:]
-        
+
         if not split_models:
-            self.strucm.save_structure(output_structure_path, rename_terms=rename_terms, output_format=output_format)
+            self.strucm.save_structure(
+                output_structure_path, 
+                rename_terms=rename_terms, 
+                output_format=output_format, 
+                keep_resnames=self.args['keep_canonical']
+            )
         else:
             for mod in self.strucm.st.get_models():
                 output_path = f'{output_structure_path}_{mod.serial_num}.{output_format}'
-                self.strucm.save_structure(output_path, mod_id = mod.id, rename_terms=rename_terms, output_format=output_format)
+                self.strucm.save_structure(
+                    output_path, 
+                    mod_id = mod.id, 
+                    rename_terms=rename_terms, 
+                    output_format=output_format, 
+                    keep_resnames=self.args['keep_canonical']
+                )
             print(cts.MSGS["SPLIT_MODELS"])
         
         return output_structure_path

--- a/biobb_structure_checking/structure_manager.py
+++ b/biobb_structure_checking/structure_manager.py
@@ -95,6 +95,7 @@ class StructureManager:
 
         self.backbone_links = []
         self.modified_residue_list = []
+        self.non_canonical_residue_list = []
 
         self.hetatm = {}
         self.num_res = 0
@@ -298,7 +299,6 @@ class StructureManager:
         print("Total assigned charge: {:10.2f}".format(self.total_charge))
 
         self.has_charges = True
-
 
     def guess_hetatm(self):
         """ Guesses HETATM type as modified res, metal, wat, organic
@@ -780,14 +780,17 @@ class StructureManager:
             output_pdb_path: str, 
             mod_id: str = None, 
             rename_terms: bool = False, 
-            output_format='pdb'):
+            output_format: str = 'pdb',
+            keep_resnames: bool = False):
         """
         Saves structure on disk in PDB format
 
         Args:
             output_pdb_path: OS path to the output file
             mod_id (optional): model to write
-
+            rename_terms: rename terminal residues
+            output_format: select output format
+            keep_resnames: keep canonical residue names
         Errors:
             OSError: Error saving the file
         """
@@ -800,12 +803,19 @@ class StructureManager:
         else:
             self.revert_terms()
 
+        if keep_resnames:
+            self.revert_can_resnames(canonical=True)
+            print("Warning: reverting residue names to canonical on output")
+
         if mod_id is None:
             pdbio.set_structure(self.st)
             pdbio.save(output_pdb_path)
         else:
             pdbio.set_structure(self.st[mod_id])
             pdbio.save(output_pdb_path)
+        
+        if keep_resnames:
+            self.revert_can_resnames(canonical=False)
 
     def get_all_r2r_distances(self, res_group: Union[str, Iterable[str]], join_models: bool) -> List[Tuple[Residue, Residue, float]]:
         """ Determine residue pairs within a given Cutoff distance
@@ -1317,7 +1327,6 @@ class StructureManager:
                 rcode_can = self.data_library.canonical_codes[rcode]
             else:
                 rcode_can = rcode
-
             
             if rcode_can not in add_h_rules:              
                 print(NotAValidResidueError(rcode).message)
@@ -1342,6 +1351,7 @@ class StructureManager:
                     h_rules[ion_res_list[res]]
                 )
                 res.resname = ion_res_list[res]
+                self.non_canonical_residue_list.append({'res':res, 'can_res':rcode_can, 'new_res':res.resname})
             else:
                 error_msg = mu.add_hydrogens_side(res, self.res_library, rcode, h_rules)
 
@@ -1361,6 +1371,7 @@ class StructureManager:
             if 'HG' in res:
                 mu.remove_atom_from_res(res, 'HG')
             res.resname = 'CYX'
+            self.non_canonical_residue_list.append({'res':res, 'can_res':'CYS', 'new_res':res.resname})
         self.modified = True
 
     def rename_terms(self, term_res):
@@ -1374,6 +1385,14 @@ class StructureManager:
         for res in self.st.get_residues():
             if len(res.get_resname()) == 4:
                 res.resname = res.resname[1:]
+
+    def revert_can_resnames(self, canonical=True):
+        """ Revert residue names to canonical ones """
+        for mod_res in self.non_canonical_residue_list:
+            if canonical:
+                mod_res['res'].resname = mod_res['can_res']
+            else:
+                mod_res['res'].resname = mod_res['new_res']
 
     def is_N_term(self, res: Residue) -> bool:
         """ Detects whether it is N terminal residue."""


### PR DESCRIPTION
Reverts residue names changed by add_hydrogen or getSS keeping atoms unchanged. It may interfere with further operations. 